### PR TITLE
서버 시작 시 createExamObjects 메서드 실행

### DIFF
--- a/src/main/java/com/assignx/AssignxServer/domain/exam/repository/ExamRepository.java
+++ b/src/main/java/com/assignx/AssignxServer/domain/exam/repository/ExamRepository.java
@@ -1,5 +1,6 @@
 package com.assignx.AssignxServer.domain.exam.repository;
 
+import com.assignx.AssignxServer.domain.course.entity.Course;
 import com.assignx.AssignxServer.domain.exam.entity.Exam;
 import com.assignx.AssignxServer.domain.exam.entity.ExamAssigned;
 import com.assignx.AssignxServer.domain.exam.entity.ExamType;
@@ -25,4 +26,6 @@ public interface ExamRepository extends JpaRepository<Exam, Long>, JpaSpecificat
     List<Exam> findAllByYearSemesterAndExamTypeAndAssigned(
             String year, String semester, ExamType examType, ExamAssigned examAssigned
     );
+
+    Exam findByCourseAndExamType(Course course, ExamType examType);
 }

--- a/src/main/java/com/assignx/AssignxServer/domain/exam/service/ExamService.java
+++ b/src/main/java/com/assignx/AssignxServer/domain/exam/service/ExamService.java
@@ -170,6 +170,12 @@ public class ExamService {
             int professorCnt = course.getProfessorName().split(",").length;
             // TODO 실제로는 이름도 같은지 체크해야하지만 우선은 간단하게 size만 비교
             if (professorCnt == course.getProfessors().size()) {
+                // 이미 시험 객체가 존재한다면 continue
+                Exam existingExam = examRepository.findByCourseAndExamType(course, examType);
+                if (existingExam != null) {
+                    continue;
+                }
+
                 Exam exam = Exam.builder()
                         .course(course)
                         .examType(examType)

--- a/src/main/java/com/assignx/AssignxServer/global/common/service/StartupTask.java
+++ b/src/main/java/com/assignx/AssignxServer/global/common/service/StartupTask.java
@@ -1,6 +1,8 @@
 package com.assignx.AssignxServer.global.common.service;
 
 import com.assignx.AssignxServer.domain.course.service.CourseService;
+import com.assignx.AssignxServer.domain.exam.entity.ExamType;
+import com.assignx.AssignxServer.domain.exam.service.ExamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -11,9 +13,11 @@ import org.springframework.stereotype.Component;
 public class StartupTask {
 
     private final CourseService courseService;
+    private final ExamService examService;
 
     @EventListener(ApplicationReadyEvent.class)
     public void onReady() {
         courseService.getCourseListFromSY("2025", "2", "1O02");
+        examService.createExamObjects("2025", "2", ExamType.MID);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈



## 🔧 작업 내용

- 서버 시작 시 createExamObjects 메서드가 자동으로 실행되도록 StartupTask에 추가
- createExamObjects 시 이미 존재하는 exam이 있다면 스킵 (판단 기준: course & examType)

## 📋 리뷰 참고사항 



## 📸 스크린샷



## ✅ 체크리스트

- [x] 로컬 환경에서 정상적으로 동작하나요?
- [x] 불필요한 코드를 정리하였나요? (주석, print 함수 등)
- [x] 커밋 메시지가 컨벤션을 따르고 있나요?